### PR TITLE
feat(Grouped Product Swatch): account for variant switches

### DIFF
--- a/Grouped Product Swatch/styles.css
+++ b/Grouped Product Swatch/styles.css
@@ -45,6 +45,10 @@
     flex: var(--size) 0 0;
 }
 
+#options > label.unavailable {
+    opacity: 30%;
+}
+
 #options > label > input {
     appearance: none;
 }


### PR DESCRIPTION
Updating the **Grouped Product Swatch** Custom Block to open the page of the selected product, with the variant options in-tact (not reset).